### PR TITLE
Migrate iOS cloud workflows ruby setup to maintained action

### DIFF
--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -28,13 +28,6 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
-    - name: Cache Ruby gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
     - name: Fastlane Enterprise
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -26,7 +26,8 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
+        bundler-cache: true
     - name: Cache Ruby gems
       uses: actions/cache@v1
       with:
@@ -36,8 +37,6 @@ jobs:
           ${{ runner.os }}-gems-
     - name: Fastlane Enterprise
       run: |
-        gem install bundler
-        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec fastlane run increment_build_number build_number:$GITHUB_RUN_NUMBER
         bundle exec fastlane enterprise

--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - name: Cache Ruby gems

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -26,7 +26,8 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
+        bundler-cache: true
     - name: Cache Ruby gems
       uses: actions/cache@v1
       with:
@@ -36,8 +37,6 @@ jobs:
           ${{ runner.os }}-gems-
     - name: Fastlane Beta
       run: |
-        gem install bundler
-        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec fastlane beta
       env:

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - name: Cache Ruby gems

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -28,13 +28,6 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
-    - name: Cache Ruby gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
     - name: Fastlane Beta
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -26,13 +26,6 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
-    - name: Cache Ruby gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
     - name: Fastlane Test
       run: |
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - name: Cache Ruby gems

--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7
+        bundler-cache: true
     - name: Cache Ruby gems
       uses: actions/cache@v1
       with:
@@ -34,8 +35,6 @@ jobs:
           ${{ runner.os }}-gems-
     - name: Fastlane Test
       run: |
-        gem install bundler
-        bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec fastlane test
       env:


### PR DESCRIPTION
Migrate iOS cloud workflows ruby setup from https://github.com/actions/setup-ruby/blob/main/README.md action, which is no longer maintained, to https://github.com/ruby/setup-ruby.