### PR TITLE
Add timeout to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -25,6 +25,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   release:
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   test:
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   build:
     runs-on: self-hosted
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   release:
     runs-on: self-hosted
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test:
     runs-on: self-hosted
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/universal-cloud-backup.yml
+++ b/.github/workflows/universal-cloud-backup.yml
@@ -27,6 +27,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -5,6 +5,8 @@ on: [pull_request]
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v2
       - name: Download actionlint


### PR DESCRIPTION
I think that 30 minutes is enough. If there would be a problem with it, we can simply increase it in the future.