### PR TITLE
Change deletion to force in selfhosted backup workflow

### DIFF
--- a/.github/workflows/universal-selfhosted-backup.yml
+++ b/.github/workflows/universal-selfhosted-backup.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Remove backup remote if already exists
       run: git remote rm backup || true
     - name: Clean temp
-      run : rm /tmp/ssh-auth.sock
+      run : rm /tmp/ssh-auth.sock || true
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/universal-selfhosted-backup.yml
+++ b/.github/workflows/universal-selfhosted-backup.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Remove backup remote if already exists
       run: git remote rm backup || true
     - name: Clean temp
-      run : rm /tmp/ssh-auth.sock || true
+      run : rm -f /tmp/ssh-auth.sock
     - name: Checkout
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Aktuálně pokud chybí daný temp soubor, tak workflow failne s chybou `rm: /tmp/ssh-auth.sock: No such file or directory`