### PR TITLE
Housekeep: Update checkout action

### DIFF
--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Setup SSH key

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Setup SSH key

--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
         fetch-depth: 0

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Fastlane Enterprise

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Fastlane Beta

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
         fetch-depth: 0

--- a/.github/workflows/universal-cloud-backup.yml
+++ b/.github/workflows/universal-cloud-backup.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
         fetch-depth: 0 # Make deep copy

--- a/.github/workflows/universal-selfhosted-backup.yml
+++ b/.github/workflows/universal-selfhosted-backup.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Clean temp
       run : rm /tmp/ssh-auth.sock
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         lfs: ${{ inputs.use_git_lfs }}
         fetch-depth: 0 # Make deep copy

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)


### PR DESCRIPTION
`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/upload-artifact, actions/upload-artifact, actions/checkout
`