### PR TITLE
Support custom environment variables

### DIFF
--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -7,6 +7,10 @@ on:
         description: Whether to download Git-LFS files.
         type: boolean
         required: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       SSH_PRIVATE_KEY:
         required: true
@@ -60,6 +64,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}
     - name: Upload IPA
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -7,6 +7,10 @@ on:
         description: Whether to download Git-LFS files.
         type: boolean
         required: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       SSH_PRIVATE_KEY:
         required: true
@@ -72,6 +76,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}
     - name: Upload IPA
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -7,6 +7,10 @@ on:
         description: Whether to download Git-LFS files.
         type: boolean
         required: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       SSH_PRIVATE_KEY:
         required: true
@@ -45,3 +49,4 @@ jobs:
         bundle exec fastlane test
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}

--- a/.github/workflows/ios-kmp-selfhosted-build.yml
+++ b/.github/workflows/ios-kmp-selfhosted-build.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -73,6 +77,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}
     - name: Upload IPA
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -62,6 +66,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}
     - name: Upload IPA
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ios-kmp-selfhosted-test.yml
+++ b/.github/workflows/ios-kmp-selfhosted-test.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -56,3 +60,4 @@ jobs:
         bundle exec fastlane test
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -47,6 +51,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}
     - name: Upload IPA
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -59,6 +63,7 @@ jobs:
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID_CUSTOMER || secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}
     - name: Upload IPA
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: false
+      custom_values:
+        description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
+        type: string
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -31,3 +35,4 @@ jobs:
         bundle exec fastlane test
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CUSTOM_VALUES: ${{ inputs.custom_values }}


### PR DESCRIPTION
ENV values zadefinované v súbore workflow špecifického projektu sa nedostanú až do Fastfile. Je to z dôvodu že firemný workflow ich nezadefinuje do konkrétneho stepu, ktorý volá Fastfile. 

Úlohou tohto parametru je zobrať string "pseudo dic", ktorý sa následne vloží do stepu, ktorý volá Fastfile. Vďaka tomu je možné stále využívať firemný workflow + si zadefinovať custom hodnoty. 

Doposiaľ bez tohto parametru sa firemný workflow copy pastol na konkrétny projekt a pridali sa do neho custom hodnoty.