### PR TITLE
Have option to specify runner in iOS selfhosted builds

### DIFF
--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -12,6 +12,12 @@ on:
         description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
         type: string
         required: false
+      runner_label:
+        description: 'The custom label for the self-hosted runner to use for the build job.'
+        type: string
+        required: false
+        default: 'self-hosted' # Default if you don't specify a particular runner
+
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -51,7 +57,7 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
   build:
-    runs-on: self-hosted
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 30
     needs: detect_changes
     if: ${{ needs.detect_changes.outputs.should_run != 'false' }}

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -12,6 +12,11 @@ on:
         description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
         type: string
         required: false
+      runner_label:
+        description: 'The custom label for the self-hosted runner to use for the build job.'
+        type: string
+        required: false
+        default: 'self-hosted' # Default if you don't specify a particular runner
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -32,7 +37,7 @@ on:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -12,6 +12,12 @@ on:
         description: "Custom string that can contains values specified in your workflow file. Those values will be placed into environment variable. Example: \"CUSTOM-1: 1; CUSTOM-2: 2\""
         type: string
         required: false
+      runner_label:
+        description: 'The custom label for the self-hosted runner to use for the build job.'
+        type: string
+        required: false
+        default: 'self-hosted' # Default if you don't specify a particular runner
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -19,7 +25,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
###Usage:
Ak programátor chce špecifikovať runner, musí si zistiť sám aké labels sú dostupné. Ide o funkcionalitu, ktorá by sa nemala využívať na pravidelnej báze, skôr ako možnosť v prípade potrebné hotfixu, kedy mu build umožnuje iba jeden runner. 

To môže byť z dôvodu že iný runner bol updatovaný a v aktálnom stave runneru nie je možné daný projekt buildiť. 

```
jobs:
  test:
    uses: futuredapp/.github/.github/workflows/ios-selfhosted-test.yml@main
    with:
        runner_label: 'ci-mini-1'
```
