### PR TITLE
[Legacy branch] iOS have option to specify runner

### DIFF
--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      runner_label:
+        description: 'The custom label for the self-hosted runner to use for the build job.'
+        type: string
+        required: false
+        default: 'self-hosted' # Default if you don't specify a particular runner
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -38,7 +43,7 @@ jobs:
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
   build:
-    runs-on: self-hosted
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 30
     needs: detect_changes
     if: ${{ needs.detect_changes.outputs.should_run != 'false' }}

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      runner_label:
+        description: 'The custom label for the self-hosted runner to use for the build job.'
+        type: string
+        required: false
+        default: 'self-hosted' # Default if you don't specify a particular runner
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -20,7 +25,7 @@ on:
 
 jobs:
   release:
-    runs-on: self-hosted
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -8,6 +8,11 @@ on:
         type: boolean
         required: false
         default: false
+      runner_label:
+        description: 'The custom label for the self-hosted runner to use for the build job.'
+        type: string
+        required: false
+        default: 'self-hosted' # Default if you don't specify a particular runner
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -15,7 +20,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ${{ fromJson(format('["self-hosted", "{0}"]', inputs.runner_label)) }}
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
### Usage:
Ak programátor chce špecifikovať runner, musí si zistiť sám aké labels sú dostupné. Ide o funkcionalitu, ktorá by sa nemala využívať na pravidelnej báze, skôr ako možnosť v prípade potrebné hotfixu, kedy mu build umožnuje iba jeden runner. 

To môže byť z dôvodu že iný runner bol updatovaný a v aktálnom stave runneru nie je možné daný projekt buildiť. 

### Example:
```
jobs:
  test:
    uses: futuredapp/.github/.github/workflows/ios-selfhosted-test.yml@legacy
    with:
        runner_label: 'mini'
```
