### PR TITLE
Remove unnecessary fetch depth from test

### DIFF
--- a/.github/workflows/ios-cloud-test.yml
+++ b/.github/workflows/ios-cloud-test.yml
@@ -33,7 +33,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: ${{ inputs.use_git_lfs }}
-        fetch-depth: 0
     - name: Setup SSH key
       uses: webfactory/ssh-agent@v0.8.0
       with:

--- a/.github/workflows/ios-kmp-selfhosted-test.yml
+++ b/.github/workflows/ios-kmp-selfhosted-test.yml
@@ -58,7 +58,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: ${{ inputs.use_git_lfs }}
-          fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -33,7 +33,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         lfs: ${{ inputs.use_git_lfs }}
-        fetch-depth: 0
     - name: Fastlane Test
       run: |
         gem install bundler


### PR DESCRIPTION
# Remove unnecessary fetch-depth from test workflows

## Changes
- Removed `fetch-depth: 0` parameter from test workflows as it's not needed for running tests
- This change affects the following files:
  - `.github/workflows/ios-cloud-test.yml`
  - `.github/workflows/ios-kmp-selfhosted-test.yml`
  - `.github/workflows/ios-selfhosted-test.yml`

## Why
- The default `fetch-depth: 1` is sufficient for test workflows since we only need the latest code state
- This change will:
  - Speed up the checkout process
  - Reduce disk space usage
  - Follow GitHub Actions best practices

## Note
- The `fetch-depth: 0` setting remains in backup workflows where a full history is required