### PR TITLE
 Add force build option

### DIFF
--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -70,7 +70,6 @@ jobs:
 
     - name: Use Composite Action - Detect changes and get changelog
       id: detect_changes
-      if: ${{ inputs.force_build != true }}
       uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@main
       with:
         debug: ${{ inputs.changelog_debug }}

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -79,7 +79,7 @@ jobs:
       if: ${{ inputs.force_build == true }}
       id: changelog
       run: |
-        echo "changelog=Forced build" >> $GITHUB_OUTPUT
+        echo "changelog=Forced build" >> "$GITHUB_OUTPUT"
         
     - name: Fastlane Beta
       if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == true }}

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -32,6 +32,11 @@ on:
         type: string
         required: false
         default: "24 hours"
+      force_build:
+        description: "If true, skip change detection and force a build."
+        type: boolean
+        required: false
+        default: false
     secrets:
       MATCH_PASSWORD:
         required: true
@@ -57,54 +62,60 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: Use Composite Action - Detect changes and get changelog
-      id: detect_changes
-      uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@main
-      with:
-        checkout_depth: ${{ inputs.changelog_checkout_depth }}
-        debug: ${{ inputs.changelog_debug }}
-        fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
-
     - name: Checkout
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' && inputs.use_git_lfs == 'true'  }}
       uses: actions/checkout@v4
       with:
         lfs: ${{ inputs.use_git_lfs }}
+        fetch-depth: ${{ inputs.changelog_checkout_depth }}
 
+    - name: Use Composite Action - Detect changes and get changelog
+      id: detect_changes
+      if: ${{ inputs.force_build != 'true' }}
+      uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@main
+      with:
+        debug: ${{ inputs.changelog_debug }}
+        fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
+
+    - name: Set changelog for forced build
+      if: ${{ inputs.force_build == 'true' }}
+      id: changelog
+      run: |
+        echo "changelog=Forced build" >> $GITHUB_OUTPUT
+        
     - name: Fastlane Beta
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' }}
+      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == 'true' }}
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        CHANGELOG_FOR_FASTLANE="${{ steps.detect_changes.outputs.changelog }}"
+        CHANGELOG_FOR_FASTLANE="${{ steps.detect_changes.outputs.changelog || steps.changelog.outputs.changelog }}"
         if [ "${{ inputs.changelog_debug }}" == 'true' ]; then
           echo "[DEBUG] Running Fastlane with changelog: $CHANGELOG_FOR_FASTLANE"
         fi
         bundle exec fastlane beta
       env:
         MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-        PR_TITLE: ${{ steps.detect_changes.outputs.changelog }}
+        PR_TITLE: ${{ steps.detect_changes.outputs.changelog || steps.changelog.outputs.changelog }}
         APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
         CUSTOM_VALUES: ${{ inputs.custom_values }}
 
     - name: Upload IPA
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' }}
+      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: Build.ipa
         path: build_output/*.ipa
 
     - name: Upload dSYM
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' }}
+      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: Build.app.dSYM.zip
         path: build_output/*.app.dSYM.zip
 
     - name: Save latest build commit SHA to file
-      if: success() && steps.detect_changes.outputs.skip_build != 'true'
+      if: success() && steps.detect_changes.outputs.skip_build != 'true' && inputs.force_build != 'true'
       shell: bash
       run: |
         echo "${{ github.sha }}" > latest_builded_commit.txt
@@ -113,7 +124,7 @@ jobs:
         fi
 
     - name: Store latest build commit SHA in cache
-      if: success() && steps.detect_changes.outputs.skip_build != 'true'
+      if: success() && steps.detect_changes.outputs.skip_build != 'true' && inputs.force_build != 'true'
       uses: actions/cache/save@v4
       with:
         path: latest_builded_commit.txt

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -70,20 +70,20 @@ jobs:
 
     - name: Use Composite Action - Detect changes and get changelog
       id: detect_changes
-      if: ${{ inputs.force_build != 'true' }}
+      if: ${{ inputs.force_build != true }}
       uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@main
       with:
         debug: ${{ inputs.changelog_debug }}
         fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
 
     - name: Set changelog for forced build
-      if: ${{ inputs.force_build == 'true' }}
+      if: ${{ inputs.force_build == true }}
       id: changelog
       run: |
         echo "changelog=Forced build" >> $GITHUB_OUTPUT
         
     - name: Fastlane Beta
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == 'true' }}
+      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == true }}
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
@@ -101,21 +101,21 @@ jobs:
         CUSTOM_VALUES: ${{ inputs.custom_values }}
 
     - name: Upload IPA
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == 'true' }}
+      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == true }}
       uses: actions/upload-artifact@v4
       with:
         name: Build.ipa
         path: build_output/*.ipa
 
     - name: Upload dSYM
-      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == 'true' }}
+      if: ${{ steps.detect_changes.outputs.skip_build != 'true' || inputs.force_build == true }}
       uses: actions/upload-artifact@v4
       with:
         name: Build.app.dSYM.zip
         path: build_output/*.app.dSYM.zip
 
     - name: Save latest build commit SHA to file
-      if: success() && steps.detect_changes.outputs.skip_build != 'true' && inputs.force_build != 'true'
+      if: success() && steps.detect_changes.outputs.skip_build != 'true' && inputs.force_build != true
       shell: bash
       run: |
         echo "${{ github.sha }}" > latest_builded_commit.txt
@@ -124,7 +124,7 @@ jobs:
         fi
 
     - name: Store latest build commit SHA in cache
-      if: success() && steps.detect_changes.outputs.skip_build != 'true' && inputs.force_build != 'true'
+      if: success() && steps.detect_changes.outputs.skip_build != 'true' && inputs.force_build != true
       uses: actions/cache/save@v4
       with:
         path: latest_builded_commit.txt


### PR DESCRIPTION
This PR introduces a `force_build` input to the `ios-selfhosted-build.yml` workflow, enabling builds to proceed even if change detection would normally skip them. It also adjusts subsequent steps to respect this new input and provides a specific changelog for forced builds.

### Key Features

*   Added a `force_build` boolean input to the workflow.
*   Modified build-related steps (Fastlane, IPA/dSYM upload) to execute when `force_build` is true, bypassing change detection.
*   Introduced a specific changelog message ("Forced build") when `force_build` is active.
*   Ensured commit SHA saving and caching steps are skipped during forced builds.

### Workflow Input

| Input Name | Type | Description | Default |
| :--------- | :--- | :---------- | :------ |
| `force_build` | `boolean` | If true, skip change detection and force a build. | `false` |