### PR TITLE
Remove unnecessary check of required keys

### DIFF
--- a/.github/workflows/ios-cloud-build.yml
+++ b/.github/workflows/ios-cloud-build.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Export secrets to .xcconfig file
-      if: ${{ inputs.xcconfig_path != '' && inputs.required_keys != '' }}
+      if: ${{ inputs.xcconfig_path != '' }}
       uses: futuredapp/.github/.github/actions/export_secrets_ios@main
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}

--- a/.github/workflows/ios-cloud-release.yml
+++ b/.github/workflows/ios-cloud-release.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Export secrets to .xcconfig file
-      if: ${{ inputs.xcconfig_path != '' && inputs.required_keys != '' }}
+      if: ${{ inputs.xcconfig_path != '' }}
       uses: futuredapp/.github/.github/actions/export_secrets_ios@main
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}

--- a/.github/workflows/ios-kmp-selfhosted-build.yml
+++ b/.github/workflows/ios-kmp-selfhosted-build.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           lfs: ${{ inputs.use_git_lfs }}
       - name: Export secrets to .xcconfig file
-        if: ${{ inputs.xcconfig_path != '' && inputs.required_keys != '' }}
+        if: ${{ inputs.xcconfig_path != '' }}
         uses: futuredapp/.github/.github/actions/export_secrets_ios@main
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Export secrets to .xcconfig file
-      if: ${{ inputs.xcconfig_path != '' && inputs.required_keys != '' }}
+      if: ${{ inputs.xcconfig_path != '' }}
       uses: futuredapp/.github/.github/actions/export_secrets_ios@main
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -102,7 +102,7 @@ jobs:
         lfs: ${{ inputs.use_git_lfs }}
 
     - name: Export secrets to .xcconfig file
-      if: ${{ inputs.xcconfig_path != '' && inputs.required_keys != '' }}
+      if: ${{ inputs.xcconfig_path != '' }}
       uses: futuredapp/.github/.github/actions/export_secrets_ios@main
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Export secrets to .xcconfig file
-      if: ${{ inputs.xcconfig_path != '' && inputs.required_keys != '' }}
+      if: ${{ inputs.xcconfig_path != '' }}
       uses: futuredapp/.github/.github/actions/export_secrets_ios@main
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}


### PR DESCRIPTION
The input require keys is optional and it's functionality is only to validate if all keys provided in that input was successfully obtained from repository secrets. 

If the variable is empty the step which handle secrets injection shouldn't be skipped.