### PR TITLE
 Export secrets pwd

### DIFF
--- a/.github/actions/export_secrets_ios/action.yml
+++ b/.github/actions/export_secrets_ios/action.yml
@@ -17,8 +17,7 @@ runs:
   steps:
     - name: Run script
       shell: sh
-      working-directory: ${{ github.action_path }}
-      run: ./entrypoint.sh
+      run: ${{ github.action_path }}/entrypoint.sh
       env:
         XCCONFIG_PATH: ${{ inputs.XCCONFIG_PATH }}
         SECRET_PROPERTIES: ${{ inputs.SECRET_PROPERTIES }}


### PR DESCRIPTION
### Problem: 
The action was failing when called from other repositories because it set working-directory to the action's path, making relative file paths like iosApp/Config Files/Beta.xcconfig unresolvable.

### Solution:
Removed working-directory and used ${{ github.action_path }}/entrypoint.sh to run the script while keeping the working directory in the calling repository.