### PR TITLE
Ignore ditto zip failures in iOS test action

### DIFF
--- a/.github/actions/ios-fastlane-test/action.yml
+++ b/.github/actions/ios-fastlane-test/action.yml
@@ -28,10 +28,12 @@ runs:
 
     - name: Zip Simulator App
       shell: bash
+      continue-on-error: true
       run: ditto -c -k --keepParent ${{ runner.temp }}/DerivedData/Build/Products/Debug-iphonesimulator/*.app simulator-app.zip
 
     - name: Upload Simulator App
       uses: actions/upload-artifact@v7
+      continue-on-error: true
       with:
         name: simulator-app
         path: simulator-app.zip

--- a/.github/actions/ios-fastlane-test/action.yml
+++ b/.github/actions/ios-fastlane-test/action.yml
@@ -28,12 +28,11 @@ runs:
 
     - name: Zip Simulator App
       shell: bash
-      continue-on-error: true
-      run: ditto -c -k --keepParent ${{ runner.temp }}/DerivedData/Build/Products/Debug-iphonesimulator/*.app simulator-app.zip
+      run: ditto -c -k --keepParent ${{ runner.temp }}/DerivedData/Build/Products/Debug-iphonesimulator/*.app simulator-app.zip || true
 
     - name: Upload Simulator App
+      if: hashFiles('simulator-app.zip') != ''
       uses: actions/upload-artifact@v7
-      continue-on-error: true
       with:
         name: simulator-app
         path: simulator-app.zip

--- a/.github/actions/ios-kmp-build/action.yml
+++ b/.github/actions/ios-kmp-build/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Export secrets to .xcconfig file
       if: ${{ inputs.secret_xcconfig_path != '' }}
-      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.0
+      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.1
       with:
         XCCONFIG_PATH: ${{ inputs.secret_xcconfig_path }}
         SECRET_PROPERTIES: ${{ inputs.secret_properties }}
@@ -63,7 +63,7 @@ runs:
         cd ${{ inputs.kmp_swift_package_path }}
         make build
     - name: Fastlane Beta
-      uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.0
+      uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.1
       with:
         match_password: ${{ inputs.match_password }}
         testflight_changelog: ${{ inputs.testflight_changelog }}

--- a/.github/workflows/android-cloud-check.yml
+++ b/.github/workflows/android-cloud-check.yml
@@ -61,13 +61,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run checks
-        uses: futuredapp/.github/.github/actions/android-check@2.3.0
+        uses: futuredapp/.github/.github/actions/android-check@2.3.1
         with:
           lint_gradle_task: ${{ inputs.LINT_GRADLE_TASKS }}
           test_gradle_task: ${{ inputs.TEST_GRADLE_TASKS }}

--- a/.github/workflows/android-cloud-generate-baseline-profiles.yml
+++ b/.github/workflows/android-cloud-generate-baseline-profiles.yml
@@ -75,13 +75,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Generate baseline profiles
-        uses: futuredapp/.github/.github/actions/android-generate-baseline-profiles@2.3.0
+        uses: futuredapp/.github/.github/actions/android-generate-baseline-profiles@2.3.1
         with:
           generate_gradle_task: ${{ inputs.TASK_NAME }}
           signing_keystore_password: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}

--- a/.github/workflows/android-cloud-nightly-build.yml
+++ b/.github/workflows/android-cloud-nightly-build.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Detect changes and generate changelog
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.0
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.1
         with:
           checkout_depth: ${{ inputs.CHANGELOG_CHECKOUT_DEPTH }}
           debug: ${{ inputs.CHANGELOG_DEBUG }}
@@ -132,13 +132,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build and upload to App Distribution
-        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.0
+        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.1
         with:
           test_gradle_task: ${{ inputs.TEST_GRADLE_TASKS }}
           package_gradle_task: ${{ inputs.PACKAGE_GRADLE_TASK }}
@@ -185,7 +185,7 @@ jobs:
           fi
       - name: Transition JIRA tickets
         if: steps.check.outputs.enabled == 'true'
-        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.0
+        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.1
         with:
           jira_context: ${{ secrets.JIRA_CONTEXT }}
           transition: ${{ inputs.JIRA_TRANSITION }}

--- a/.github/workflows/android-cloud-release-firebaseAppDistribution.yml
+++ b/.github/workflows/android-cloud-release-firebaseAppDistribution.yml
@@ -96,13 +96,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build and upload to App Distribution
-        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.0
+        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.1
         with:
           test_gradle_task: ${{ inputs.TEST_GRADLE_TASKS }}
           package_gradle_task: ${{ inputs.PACKAGE_GRADLE_TASK }}

--- a/.github/workflows/android-cloud-release-googlePlay.yml
+++ b/.github/workflows/android-cloud-release-googlePlay.yml
@@ -98,12 +98,12 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
       - name: Build and release
-        uses: futuredapp/.github/.github/actions/android-build-googlePlay@2.3.0
+        uses: futuredapp/.github/.github/actions/android-build-googlePlay@2.3.1
         with:
           bundle_gradle_task: ${{ inputs.BUNDLE_GRADLE_TASK }}
           version_name: ${{ inputs.VERSION_NAME }}

--- a/.github/workflows/ios-kmp-selfhosted-build.yml
+++ b/.github/workflows/ios-kmp-selfhosted-build.yml
@@ -97,14 +97,14 @@ jobs:
         with:
           lfs: ${{ inputs.use_git_lfs }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           ruby: 'false'
       - name: Build and upload to TestFlight
-        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.3.1
         with:
           match_password: ${{ secrets.MATCH_PASSWORD }}
           app_store_connect_api_key_key: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -86,7 +86,7 @@ jobs:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Export secrets to .xcconfig file
       if: ${{ inputs.xcconfig_path != '' }}
-      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.0
+      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.1
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
         SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
@@ -109,7 +109,7 @@ jobs:
         cd ${{ inputs.kmp_swift_package_path }}
         make build
     - name: Fastlane Release
-      uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.3.0
+      uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.3.1
       with:
         match_password: ${{ secrets.MATCH_PASSWORD }}
         version_number: ${{ github.ref_name }}

--- a/.github/workflows/ios-kmp-selfhosted-test.yml
+++ b/.github/workflows/ios-kmp-selfhosted-test.yml
@@ -83,7 +83,7 @@ jobs:
           cd ${{ inputs.kmp_swift_package_path }}
           make build
       - name: Fastlane Test
-        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN_DANGER }}
           custom_values: ${{ inputs.custom_values }}

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -63,7 +63,7 @@ jobs:
           echo "::warning::This workflow ('ios-selfhosted-build.yml') is deprecated and will be removed in the future."
           echo "::warning::Please use 'ios-selfhosted-nightly-build.yml' instead."
   build:
-    uses: futuredapp/.github/.github/workflows/ios-selfhosted-nightly-build.yml@2.3.0
+    uses: futuredapp/.github/.github/workflows/ios-selfhosted-nightly-build.yml@2.3.1
     with:
       use_git_lfs: ${{ inputs.use_git_lfs }}
       custom_values: ${{ inputs.custom_values }}

--- a/.github/workflows/ios-selfhosted-nightly-build.yml
+++ b/.github/workflows/ios-selfhosted-nightly-build.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Detect changes and generate changelog
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.0
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.1
         with:
           checkout_depth: ${{ inputs.checkout_depth }}
           fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Export secrets
         if: ${{ steps.detect_changes.outputs.skip_build == 'false' && inputs.xcconfig_path != '' }}
-        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.1
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
           SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Fastlane Beta
         if: ${{ steps.detect_changes.outputs.skip_build == 'false' }}
-        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.1
         with:
           match_password: ${{ secrets.MATCH_PASSWORD }}
           testflight_changelog: ${{ steps.set_changelog.outputs.changelog }}
@@ -158,7 +158,7 @@ jobs:
           fi
       - name: Transition JIRA tickets
         if: steps.check.outputs.enabled == 'true'
-        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.0
+        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.1
         with:
           jira_context: ${{ secrets.JIRA_CONTEXT }}
           transition: ${{ inputs.jira_transition }}

--- a/.github/workflows/ios-selfhosted-on-demand-build.yml
+++ b/.github/workflows/ios-selfhosted-on-demand-build.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Generate changelog if not provided
         if: ${{ inputs.changelog == '' }}
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.0
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.1
         with:
           checkout_depth: ${{ inputs.checkout_depth }}
           fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
@@ -104,14 +104,14 @@ jobs:
 
       - name: Export secrets
         if: ${{ inputs.xcconfig_path != '' }}
-        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.1
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
           SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
           REQUIRED_KEYS: ${{ inputs.required_keys }}
 
       - name: Fastlane Beta
-        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.1
         with:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           testflight_changelog: ${{ steps.set_changelog.outputs.changelog }}

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Export secrets
         if: ${{ inputs.xcconfig_path != '' }}
-        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.1
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
           SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
           REQUIRED_KEYS: ${{ inputs.required_keys }}
 
       - name: Fastlane Release
-        uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.3.1
         with:
           match_password: ${{ secrets.MATCH_PASSWORD }}
           version_number: ${{ github.ref_name }}

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -41,7 +41,7 @@ jobs:
           lfs: ${{ inputs.use_git_lfs }}
 
       - name: Fastlane Test
-        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.3.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN_DANGER }}
           custom_values: ${{ inputs.custom_values }}

--- a/.github/workflows/kmp-cloud-detect-changes.yml
+++ b/.github/workflows/kmp-cloud-detect-changes.yml
@@ -28,7 +28,7 @@ name: Detect Changes
 #
 # Note: For direct action usage in other workflows, you can also use:
 #   - name: Detect Changes
-#     uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.3.0
+#     uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.3.1
 
 on:
   workflow_call:
@@ -58,6 +58,6 @@ jobs:
     steps:
       - name: Detect Changes
         id: detect
-        uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.3.0
+        uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.3.1
         with:
           USE_GIT_LFS: ${{ inputs.USE_GIT_LFS }}

--- a/.github/workflows/kmp-combined-nightly-build.yml
+++ b/.github/workflows/kmp-combined-nightly-build.yml
@@ -152,7 +152,7 @@ jobs:
     steps:
       - name: Detect changes and generate changelog
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.0
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.1
         with:
           checkout_depth: ${{ inputs.CHANGELOG_CHECKOUT_DEPTH }}
           debug: ${{ inputs.CHANGELOG_DEBUG }}
@@ -171,14 +171,14 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           ruby: 'false'
       - name: Build and upload to TestFlight
-        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.3.0
+        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.3.1
         with:
           match_password: ${{ secrets.IOS_MATCH_PASSWORD }}
           app_store_connect_api_key_key: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_KEY }}
@@ -208,13 +208,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.0
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.1
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build and upload to App Distribution
-        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.0
+        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.1
         with:
           test_gradle_task: ${{ inputs.ANDROID_TEST_GRADLE_TASK }}
           package_gradle_task: ${{ inputs.ANDROID_PACKAGE_GRADLE_TASK }}
@@ -270,7 +270,7 @@ jobs:
           fi
       - name: Transition JIRA tickets
         if: steps.check.outputs.enabled == 'true'
-        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.0
+        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.1
         with:
           jira_context: ${{ secrets.JIRA_CONTEXT }}
           transition: ${{ inputs.JIRA_TRANSITION }}


### PR DESCRIPTION
## Summary
- Fixes `ditto: Can't archive multiple sources` error that fails iOS test jobs (e.g. gmlh-ios)
- Adds `|| true` to the ditto zip command so failures are silently ignored
- Conditionally skips the upload step if no zip was produced
- Note: `continue-on-error` does not work in composite action steps — shell-level suppression is required

## Important
After merging, a **new version tag** must be created for consumer repos to pick up the fix (all action references are pinned to `@2.3.0`).

## Test plan
- [ ] Verify iOS test workflow still passes when `.app` is present (zip + upload work as before)
- [ ] Verify iOS test workflow passes when no `.app` is found (ditto fails silently, job succeeds)
- [ ] Verify iOS test workflow passes when multiple `.app` files exist (the gmlh-ios case)