### PR TITLE
fix(ci): filter out intermediate mapping files

### DIFF
--- a/.github/actions/android-build-googlePlay/action.yml
+++ b/.github/actions/android-build-googlePlay/action.yml
@@ -72,7 +72,7 @@ runs:
       run: |
         ./gradlew ${{ inputs.bundle_gradle_task }} -P buildkonfig.flavor="$KMP_FLAVOR"
         BUNDLE_FILE=$(find . -name '*.aab' | grep -v -e '.*intermediate' -e '.*baseline')
-        MAPPING_FILE=$(find . -name mapping.txt)
+        MAPPING_FILE=$(find . -name mapping.txt -not -path '*/intermediates/*')
         
         echo "bundle_file=$BUNDLE_FILE" >> "$GITHUB_OUTPUT"
         echo "mapping_file=$MAPPING_FILE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Update the `find` command in the `android-build-googlePlay` action to ignore `mapping.txt` files located within `intermediates` directories. This ensures that only the final obfuscation mapping file is selected for the build output.