### PR TITLE
Add timeout_minutes input to KMP release + bump refs to 2.4.0

### DIFF
--- a/.github/actions/ios-kmp-build/action.yml
+++ b/.github/actions/ios-kmp-build/action.yml
@@ -48,7 +48,7 @@ runs:
   steps:
     - name: Export secrets to .xcconfig file
       if: ${{ inputs.secret_xcconfig_path != '' }}
-      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.3
+      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.4.0
       with:
         XCCONFIG_PATH: ${{ inputs.secret_xcconfig_path }}
         SECRET_PROPERTIES: ${{ inputs.secret_properties }}
@@ -63,7 +63,7 @@ runs:
         cd ${{ inputs.kmp_swift_package_path }}
         make build
     - name: Fastlane Beta
-      uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.3
+      uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.4.0
       with:
         match_password: ${{ inputs.match_password }}
         testflight_changelog: ${{ inputs.testflight_changelog }}

--- a/.github/workflows/android-cloud-check.yml
+++ b/.github/workflows/android-cloud-check.yml
@@ -61,13 +61,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run checks
-        uses: futuredapp/.github/.github/actions/android-check@2.3.3
+        uses: futuredapp/.github/.github/actions/android-check@2.4.0
         with:
           lint_gradle_task: ${{ inputs.LINT_GRADLE_TASKS }}
           test_gradle_task: ${{ inputs.TEST_GRADLE_TASKS }}

--- a/.github/workflows/android-cloud-generate-baseline-profiles.yml
+++ b/.github/workflows/android-cloud-generate-baseline-profiles.yml
@@ -75,13 +75,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Generate baseline profiles
-        uses: futuredapp/.github/.github/actions/android-generate-baseline-profiles@2.3.3
+        uses: futuredapp/.github/.github/actions/android-generate-baseline-profiles@2.4.0
         with:
           generate_gradle_task: ${{ inputs.TASK_NAME }}
           signing_keystore_password: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}

--- a/.github/workflows/android-cloud-nightly-build.yml
+++ b/.github/workflows/android-cloud-nightly-build.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Detect changes and generate changelog
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.3
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.4.0
         with:
           checkout_depth: ${{ inputs.CHANGELOG_CHECKOUT_DEPTH }}
           debug: ${{ inputs.CHANGELOG_DEBUG }}
@@ -132,13 +132,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build and upload to App Distribution
-        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.3
+        uses: futuredapp/.github/.github/actions/android-build-firebase@2.4.0
         with:
           test_gradle_task: ${{ inputs.TEST_GRADLE_TASKS }}
           package_gradle_task: ${{ inputs.PACKAGE_GRADLE_TASK }}
@@ -185,7 +185,7 @@ jobs:
           fi
       - name: Transition JIRA tickets
         if: steps.check.outputs.enabled == 'true'
-        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.3
+        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.4.0
         with:
           jira_context: ${{ secrets.JIRA_CONTEXT }}
           transition: ${{ inputs.JIRA_TRANSITION }}

--- a/.github/workflows/android-cloud-release-firebaseAppDistribution.yml
+++ b/.github/workflows/android-cloud-release-firebaseAppDistribution.yml
@@ -96,13 +96,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build and upload to App Distribution
-        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.3
+        uses: futuredapp/.github/.github/actions/android-build-firebase@2.4.0
         with:
           test_gradle_task: ${{ inputs.TEST_GRADLE_TASKS }}
           package_gradle_task: ${{ inputs.PACKAGE_GRADLE_TASK }}

--- a/.github/workflows/android-cloud-release-googlePlay.yml
+++ b/.github/workflows/android-cloud-release-googlePlay.yml
@@ -108,12 +108,12 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
       - name: Build and release
-        uses: futuredapp/.github/.github/actions/android-build-googlePlay@2.3.3
+        uses: futuredapp/.github/.github/actions/android-build-googlePlay@2.4.0
         with:
           bundle_gradle_task: ${{ inputs.BUNDLE_GRADLE_TASK }}
           version_name: ${{ inputs.VERSION_NAME }}

--- a/.github/workflows/ios-kmp-selfhosted-build.yml
+++ b/.github/workflows/ios-kmp-selfhosted-build.yml
@@ -97,14 +97,14 @@ jobs:
         with:
           lfs: ${{ inputs.use_git_lfs }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.java_version }}
           java_distribution: ${{ inputs.java_distribution }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           ruby: 'false'
       - name: Build and upload to TestFlight
-        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.4.0
         with:
           match_password: ${{ secrets.MATCH_PASSWORD }}
           app_store_connect_api_key_key: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -91,7 +91,7 @@ jobs:
         lfs: ${{ inputs.use_git_lfs }}
     - name: Export secrets to .xcconfig file
       if: ${{ inputs.xcconfig_path != '' }}
-      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.3
+      uses: futuredapp/.github/.github/actions/ios-export-secrets@2.4.0
       with:
         XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
         SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
@@ -114,7 +114,7 @@ jobs:
         cd ${{ inputs.kmp_swift_package_path }}
         make build
     - name: Fastlane Release
-      uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.3.3
+      uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.4.0
       with:
         match_password: ${{ secrets.MATCH_PASSWORD }}
         version_number: ${{ github.ref_name }}

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -51,6 +51,11 @@ on:
         description: "Path to directory containing Fastfile. If not specified, uses iosApp. Example: iosApp/appA"
         type: string
         required: false
+      timeout_minutes:
+        description: 'Job timeout in minutes'
+        type: number
+        required: false
+        default: 30
 
     secrets:
       MATCH_PASSWORD:
@@ -77,7 +82,7 @@ on:
 jobs:
   release:
     runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/ios-kmp-selfhosted-test.yml
+++ b/.github/workflows/ios-kmp-selfhosted-test.yml
@@ -83,7 +83,7 @@ jobs:
           cd ${{ inputs.kmp_swift_package_path }}
           make build
       - name: Fastlane Test
-        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN_DANGER }}
           custom_values: ${{ inputs.custom_values }}

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -63,7 +63,7 @@ jobs:
           echo "::warning::This workflow ('ios-selfhosted-build.yml') is deprecated and will be removed in the future."
           echo "::warning::Please use 'ios-selfhosted-nightly-build.yml' instead."
   build:
-    uses: futuredapp/.github/.github/workflows/ios-selfhosted-nightly-build.yml@2.3.3
+    uses: futuredapp/.github/.github/workflows/ios-selfhosted-nightly-build.yml@2.4.0
     with:
       use_git_lfs: ${{ inputs.use_git_lfs }}
       custom_values: ${{ inputs.custom_values }}

--- a/.github/workflows/ios-selfhosted-nightly-build.yml
+++ b/.github/workflows/ios-selfhosted-nightly-build.yml
@@ -80,7 +80,7 @@ jobs:
     steps:
       - name: Detect changes and generate changelog
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.3
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.4.0
         with:
           checkout_depth: ${{ inputs.checkout_depth }}
           fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Export secrets
         if: ${{ steps.detect_changes.outputs.skip_build == 'false' && inputs.xcconfig_path != '' }}
-        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.4.0
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
           SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
@@ -102,7 +102,7 @@ jobs:
 
       - name: Fastlane Beta
         if: ${{ steps.detect_changes.outputs.skip_build == 'false' }}
-        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.4.0
         with:
           match_password: ${{ secrets.MATCH_PASSWORD }}
           testflight_changelog: ${{ steps.set_changelog.outputs.changelog }}
@@ -158,7 +158,7 @@ jobs:
           fi
       - name: Transition JIRA tickets
         if: steps.check.outputs.enabled == 'true'
-        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.3
+        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.4.0
         with:
           jira_context: ${{ secrets.JIRA_CONTEXT }}
           transition: ${{ inputs.jira_transition }}

--- a/.github/workflows/ios-selfhosted-on-demand-build.yml
+++ b/.github/workflows/ios-selfhosted-on-demand-build.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Generate changelog if not provided
         if: ${{ inputs.changelog == '' }}
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.3
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.4.0
         with:
           checkout_depth: ${{ inputs.checkout_depth }}
           fallback_lookback: ${{ inputs.changelog_fallback_lookback }}
@@ -104,14 +104,14 @@ jobs:
 
       - name: Export secrets
         if: ${{ inputs.xcconfig_path != '' }}
-        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.4.0
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
           SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
           REQUIRED_KEYS: ${{ inputs.required_keys }}
 
       - name: Fastlane Beta
-        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-fastlane-beta@2.4.0
         with:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           testflight_changelog: ${{ steps.set_changelog.outputs.changelog }}

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Export secrets
         if: ${{ inputs.xcconfig_path != '' }}
-        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-export-secrets@2.4.0
         with:
           XCCONFIG_PATH: ${{ inputs.xcconfig_path }}
           SECRET_PROPERTIES: ${{ secrets.SECRET_PROPERTIES }}
           REQUIRED_KEYS: ${{ inputs.required_keys }}
 
       - name: Fastlane Release
-        uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.4.0
         with:
           match_password: ${{ secrets.MATCH_PASSWORD }}
           version_number: ${{ github.ref_name }}

--- a/.github/workflows/ios-selfhosted-test.yml
+++ b/.github/workflows/ios-selfhosted-test.yml
@@ -41,7 +41,7 @@ jobs:
           lfs: ${{ inputs.use_git_lfs }}
 
       - name: Fastlane Test
-        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-fastlane-test@2.4.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN_DANGER }}
           custom_values: ${{ inputs.custom_values }}

--- a/.github/workflows/kmp-cloud-detect-changes.yml
+++ b/.github/workflows/kmp-cloud-detect-changes.yml
@@ -28,7 +28,7 @@ name: Detect Changes
 #
 # Note: For direct action usage in other workflows, you can also use:
 #   - name: Detect Changes
-#     uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.3.3
+#     uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.4.0
 
 on:
   workflow_call:
@@ -58,6 +58,6 @@ jobs:
     steps:
       - name: Detect Changes
         id: detect
-        uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.3.3
+        uses: futuredapp/.github/.github/actions/kmp-detect-changes@2.4.0
         with:
           USE_GIT_LFS: ${{ inputs.USE_GIT_LFS }}

--- a/.github/workflows/kmp-combined-nightly-build.yml
+++ b/.github/workflows/kmp-combined-nightly-build.yml
@@ -152,7 +152,7 @@ jobs:
     steps:
       - name: Detect changes and generate changelog
         id: detect_changes
-        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.3.3
+        uses: futuredapp/.github/.github/actions/universal-detect-changes-and-generate-changelog@2.4.0
         with:
           checkout_depth: ${{ inputs.CHANGELOG_CHECKOUT_DEPTH }}
           debug: ${{ inputs.CHANGELOG_DEBUG }}
@@ -171,14 +171,14 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           ruby: 'false'
       - name: Build and upload to TestFlight
-        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.3.3
+        uses: futuredapp/.github/.github/actions/ios-kmp-build@2.4.0
         with:
           match_password: ${{ secrets.IOS_MATCH_PASSWORD }}
           app_store_connect_api_key_key: ${{ secrets.IOS_APP_STORE_CONNECT_API_KEY_KEY }}
@@ -208,13 +208,13 @@ jobs:
         with:
           lfs: ${{ inputs.USE_GIT_LFS }}
       - name: Set up environment
-        uses: futuredapp/.github/.github/actions/android-setup-environment@2.3.3
+        uses: futuredapp/.github/.github/actions/android-setup-environment@2.4.0
         with:
           java_version: ${{ inputs.JAVA_VERSION }}
           java_distribution: ${{ inputs.JAVA_DISTRIBUTION }}
           gradle_cache_encryption_key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build and upload to App Distribution
-        uses: futuredapp/.github/.github/actions/android-build-firebase@2.3.3
+        uses: futuredapp/.github/.github/actions/android-build-firebase@2.4.0
         with:
           test_gradle_task: ${{ inputs.ANDROID_TEST_GRADLE_TASK }}
           package_gradle_task: ${{ inputs.ANDROID_PACKAGE_GRADLE_TASK }}
@@ -270,7 +270,7 @@ jobs:
           fi
       - name: Transition JIRA tickets
         if: steps.check.outputs.enabled == 'true'
-        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.3.3
+        uses: futuredapp/.github/.github/actions/jira-transition-tickets@2.4.0
         with:
           jira_context: ${{ secrets.JIRA_CONTEXT }}
           transition: ${{ inputs.JIRA_TRANSITION }}


### PR DESCRIPTION
## Context

The team needs to override the job timeout for long-running KMP release builds. KMP releases can run 25–30+ min and risk hitting the default 30‑minute cap.

Setting `timeout-minutes` directly on a caller job that `uses:` a reusable workflow is rejected by GitHub:

```
Invalid workflow file: ... Unexpected value 'uses', 'with', 'secrets', Required property is missing: runs-on
```

A job calling a reusable workflow cannot also set `timeout-minutes`, so the timeout must be exposed as an **input** on the reusable workflow itself.

## Changes

**1. Add `timeout_minutes` input to `ios-kmp-selfhosted-release.yml`**

This was the only build/release workflow with a **hardcoded** `timeout-minutes: 30`. Every other build/release workflow (`android-cloud-*`, `ios-selfhosted-*`, `ios-kmp-selfhosted-build`, `kmp-combined-nightly-build`) already exposes a configurable timeout — this brings the KMP release into line.

- Add optional `timeout_minutes` input (`type: number`, `default: 30`), matching the existing iOS house style.
- Wire it in: `timeout-minutes: 30` → `timeout-minutes: ${{ inputs.timeout_minutes }}`.

Behavior is unchanged for existing callers (default stays 30). Callers can now override:

```yaml
jobs:
  release:
    uses: futuredapp/.github/.github/workflows/ios-kmp-selfhosted-release.yml@2.4.0
    with:
      timeout_minutes: 45
```

**2. Bump internal action refs to `2.4.0`** (new minor release)

Ran `.github/scripts/bump-action-refs.sh 2.4.0` so consumers can reference the new input via a tagged ref. Tag `2.4.0` to be created after merge.

## Notes

- Passes `actionlint`.
- Input docs are auto-generated by `deploy-docs.yml` — no manual doc edits.
