### PR TITLE
Fix empty iOS release version on `release` event

### DIFF
--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -117,7 +117,7 @@ jobs:
       uses: futuredapp/.github/.github/actions/ios-fastlane-release@2.4.1
       with:
         match_password: ${{ secrets.MATCH_PASSWORD }}
-        version_number: ${{ github.ref_name }}
+        version_number: ${{ github.event.release.tag_name || github.ref_name }}
         app_store_connect_api_key_key: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
         app_store_connect_api_key_key_id: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
         app_store_connect_api_key_issuer_id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}


### PR DESCRIPTION
## Problem

The reusable iOS release workflow `ios-kmp-selfhosted-release.yml` derives the Fastlane version from `github.ref_name`:

```yaml
version_number: ${{ github.ref_name }}
```

On a **`release`-triggered** run (`on: release: [published]`), `github.ref_name` is empty. The downstream `ios-fastlane-release` action maps it to `VERSION_TAG` for `parse-version-tag.sh`, which then fails:

```
##[error]Tag '' does not match expected format 'x.y.z' or 'x.y.z-*' (any suffix after - is ignored)
##[error]Process completed with exit code 1.
```

Observed in `uniapp-kmp` release `1.0.7` ([failed run](https://github.com/futuredapp/uniapp-kmp/actions/runs/27949227076/job/82741391724)). It reproduces on the first attempt (not a re-run artifact), and the Android job in the same run — which reads `github.event.release.tag_name` — succeeded with `1.0.7`.

## Fix

Prefer the release payload, fall back to `github.ref_name`:

```yaml
version_number: ${{ github.event.release.tag_name || github.ref_name }}
```

- **`release` events** → uses `github.event.release.tag_name` (the actual tag, and it survives re-runs since it comes from the stored event payload).
- **push-tag events** → `github.event.release` is `null`, so it falls back to `github.ref_name` (the tag). Fully backward compatible; no input/interface change.

## Release / rollout

Needs a new tag (e.g. `2.4.2`) after merge. Consumers (e.g. `uniapp-kmp/.github/workflows/on_release.yml`) then bump their `ios-kmp-selfhosted-release.yml@…` ref to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)