### PR TITLE
Cache key prefix & whatsnew directory optional

### DIFF
--- a/.github/workflows/android-cloud-nightly-build.yml
+++ b/.github/workflows/android-cloud-nightly-build.yml
@@ -76,6 +76,10 @@ on:
         type: string
         required: false
         default: "24 hours"
+      CHANGELOG_CACHE_KEY_PREFIX:
+        description: "Custom prefix for cache keys used by changelog generation. If not provided, will use 'latest_builded_commit-'. If provided, format will be '{prefix}-latest_builded_commit-'."
+        type: string
+        required: false
       TIMEOUT_MINUTES:
         description: "Job timeout in minutes"
         required: false
@@ -118,6 +122,7 @@ jobs:
           checkout_depth: ${{ inputs.CHANGELOG_CHECKOUT_DEPTH }}
           debug: ${{ inputs.CHANGELOG_DEBUG }}
           fallback_lookback: ${{ inputs.CHANGELOG_FALLBACK_LOOKBACK }}
+          cache_key_prefix: ${{ inputs.CHANGELOG_CACHE_KEY_PREFIX }}
   build:
     name: Enterprise build
     runs-on: ubuntu-latest

--- a/.github/workflows/android-cloud-release-googlePlay.yml
+++ b/.github/workflows/android-cloud-release-googlePlay.yml
@@ -16,10 +16,6 @@ on:
         description: "Google Play applicationId"
         required: true
         type: string
-      GOOGLE_PLAY_WHATSNEW_DIRECTORY:
-        description: "Path to directory with changelog files according to documentation in https://github.com/r0adkll/upload-google-play"
-        required: true
-        type: string
 
       ## Optional Inputs
       USE_GIT_LFS:
@@ -52,6 +48,10 @@ on:
         required: false
         type: string
         default: 'draft'
+      GOOGLE_PLAY_WHATSNEW_DIRECTORY:
+        description: "Path to directory with changelog files according to documentation in https://github.com/r0adkll/upload-google-play"
+        required: false
+        type: string
       RELEASE_NAME:
         description: "Google Play release name. Defaults to VERSION_NAME if not set."
         required: false


### PR DESCRIPTION
- Add custom cache key prefix to ignore detected changes with another build variant. Typically when nightly builds are for both dev and prod
- Make whatsnew directory optional