### PR TITLE
feat: allow injecting env secrets into KMP/Gradle release builds

### DIFF
--- a/.github/actions/android-build-googlePlay/action.yml
+++ b/.github/actions/android-build-googlePlay/action.yml
@@ -55,12 +55,18 @@ inputs:
   secret_properties:
     required: false
     description: "Custom string that contains key-value properties as secrets. Contents of this secret will be placed into file specified by 'SECRET_PROPERTIES_FILE' input."
+  build_env:
+    required: false
+    default: ""
+    description: "Environment variables (KEY=VALUE, one per line) exported to $GITHUB_ENV before the Gradle build. Use for secrets the build reads via System.getenv (e.g. API gateway keys)."
 
 runs:
   using: "composite"
   steps:
     - name: Prepare Environment
       shell: bash
+      env:
+        BUILD_ENV: ${{ inputs.build_env }}
       run: |
         {
           echo "ANDROID_BUILD_NUMBER=$((GITHUB_RUN_NUMBER + ${{ inputs.build_number_offset}} ))";
@@ -69,6 +75,10 @@ runs:
           } >> "$GITHUB_ENV"
 
         echo '${{ inputs.secret_properties }}' > ${{ inputs.secret_properties_file }}
+
+        if [ -n "$BUILD_ENV" ]; then
+          printf '%s\n' "$BUILD_ENV" >> "$GITHUB_ENV"
+        fi
     - name: Generate Artifacts (AAB)
       id: build_aab
       shell: bash

--- a/.github/workflows/android-cloud-release-googlePlay.yml
+++ b/.github/workflows/android-cloud-release-googlePlay.yml
@@ -94,6 +94,9 @@ on:
       SECRET_PROPERTIES:
         required: false
         description: "Custom string that contains key-value properties as secrets. Contents of this secret will be placed into file specified by 'SECRET_PROPERTIES_FILE' input."
+      BUILD_ENV:
+        required: false
+        description: "Environment variables (KEY=VALUE, one per line) exported to $GITHUB_ENV before the Gradle bundle build. Use for secrets the build reads via System.getenv (e.g. API gateway keys)."
 
 jobs:
   build:
@@ -130,3 +133,4 @@ jobs:
           kmp_flavor: ${{ inputs.KMP_FLAVOR }}
           secret_properties_file: ${{ inputs.SECRET_PROPERTIES_FILE }}
           secret_properties: ${{ secrets.SECRET_PROPERTIES }}
+          build_env: ${{ secrets.BUILD_ENV }}

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -78,6 +78,12 @@ on:
         required: false
         description: >
          Secrets in the format KEY = VALUE (one per line).
+      KMP_BUILD_ENV:
+        required: false
+        description: >
+          Environment variables (KEY=VALUE, one per line) exported to $GITHUB_ENV
+          before the KMP framework build. Use for secrets the Gradle/KMP build reads
+          via System.getenv, e.g. API gateway keys baked into BuildKonfig.
 
 jobs:
   release:
@@ -105,6 +111,15 @@ jobs:
       uses: gradle/actions/setup-gradle@v5
       with:
         cache-disabled: true
+    - name: Export KMP build environment
+      if: ${{ inputs.kmp_swift_package_integration }}
+      shell: bash
+      env:
+        KMP_BUILD_ENV: ${{ secrets.KMP_BUILD_ENV }}
+      run: |
+        if [ -n "$KMP_BUILD_ENV" ]; then
+          printf '%s\n' "$KMP_BUILD_ENV" >> "$GITHUB_ENV"
+        fi
     - name: Build KMP Package
       if: ${{ inputs.kmp_swift_package_integration }}
       env:


### PR DESCRIPTION
## Problem

Reusable release workflows can only inject secrets via `secrets.properties` (Secrets Gradle plugin → BuildConfig) and `.xcconfig`. KMP projects that bake secrets into `BuildKonfig`/`BuildConfig` via `System.getenv(...)` — e.g. API gateway keys in a `ProductFlavors` definition — have no way to feed those secrets into the Gradle `bundle…` task or the KMP `make build` step.

Concrete case: the Kaktus / Mobil.cz KMP repo reads `System.getenv("KAKTUS_API_GW_KEY")` / `MOBIL_API_GW_KEY` at Gradle configuration time. It therefore can't migrate its hand-rolled release workflows to the reusable ones — doing so would silently ship a prod build with an empty API gateway key.

## Change

Add an optional, backward-compatible env-passthrough exported to `$GITHUB_ENV` **before** the build step (mirrors how `secret_properties` already works):

- **`android-build-googlePlay` action** — new `build_env` input, appended to `$GITHUB_ENV` before the Gradle bundle build.
- **`android-cloud-release-googlePlay` workflow** — new optional `BUILD_ENV` secret forwarded to the action.
- **`ios-kmp-selfhosted-release` workflow** — new optional `KMP_BUILD_ENV` secret, exported to `$GITHUB_ENV` before the KMP framework build.

All three default to empty, so **existing consumers are unaffected**.

## Usage (consumer side)

```yaml
# Android
secrets:
  BUILD_ENV: KAKTUS_API_GW_KEY=${{ secrets.KAKTUS_API_GW_KEY }}

# iOS
secrets:
  KMP_BUILD_ENV: KAKTUS_API_GW_KEY=${{ secrets.KAKTUS_API_GW_KEY }}
```

Multiple keys: one `KEY=VALUE` per line.

## Notes

- Secret values written to `$GITHUB_ENV` stay masked in logs.
- Suggest cutting a new tag (e.g. `2.5.0`) since consumers pin to tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)