### PR TITLE
Fix KMP iOS release uploading no IPA/dSYM artifacts

### DIFF
--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -128,9 +128,15 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: Build.ipa
-        path: build_output/*.ipa
+        # Fastlane writes into <ios_root_path>/build_output (iosApp/build_output here, or the
+        # custom_build_path subdirectory), so the pattern must be root-agnostic — a bare
+        # build_output/*.ipa matches nothing and silently uploads no artifact. Mirrors the
+        # ios-kmp-build action.
+        path: ./**/build_output/*.ipa
+        if-no-files-found: error
     - name: Upload dSYM
       uses: actions/upload-artifact@v7
       with:
         name: Build.app.dSYM.zip
-        path: build_output/*.app.dSYM.zip
+        path: ./**/build_output/*.app.dSYM.zip
+        if-no-files-found: error


### PR DESCRIPTION
## Problem

`ios-kmp-selfhosted-release.yml` has been uploading **zero artifacts** on every KMP iOS release, silently.

The workflow passes `ios_root_path: iosApp` to `ios-fastlane-release`, so Fastlane writes its output into **`iosApp/build_output/`** (or the `custom_build_path` subdirectory). But both upload steps globbed the workspace-root-relative `build_output/*`, which matches nothing:

```
…/akcenta-kmp/iosApp/build_output/Akcenta.ipa        ← where the IPA actually is
##[warning]No files were found with the provided path: build_output/*.ipa. No artifacts will be uploaded.
##[warning]No files were found with the provided path: build_output/*.app.dSYM.zip. No artifacts will be uploaded.
```

Because `if-no-files-found` was left at its `warn` default, both steps only **warned** — the release job stayed **green** while producing no artifacts at all. That is what made this go unnoticed.

## Impact

Two consequences, and the second one matters to every consumer of this workflow:

1. **No `Build.ipa`** — any downstream job that consumes the release artifact fails. This is how the bug was found (see below).
2. **No release dSYM archive, ever** — `Build.app.dSYM.zip` was never uploaded either. Fastlane *does* create the zip (`Compressing 6 dSYM(s)`), it just never leaves the runner, and there is no `upload_symbols_to_crashlytics` step in the release path. So **production release crashes have had no symbols available** from CI for KMP iOS projects.

## Which project surfaced it, and why it needs the artifact

**`futuredapp/akcenta-kmp`**, ticket **AK-247 — Promon Shield (RASP) integration** for the Akcenta banking app.

Akcenta shields the binary post-compile (Promon Shielder CLI runs as an Xcode build post-action) and then **re-signs** it. Because that rewrites and re-signs the shipped binary, the project added a post-release verification gate in its own `on_release.yml` that downloads the release IPA and asserts:

- the IPA really is shielded (`Shielder --check-app`),
- it carries an **Apple Distribution** identity, the signing Team ID matches the embedded provisioning profile, and it matches the expected release team.

That gate is not optional cosmetics for this project: `config-release.xml` pins the distribution certificate (`applicationSignerCertificate`), and Shield's repackaging check is *Enforced* — if the shipped IPA is signed by something that does not match the pin, the app **hard-exits at launch** with no crash report. The IPA artifact is the only thing that makes that verifiable in CI.

On akcenta-kmp release **`0.0.1`** the iOS release job went green and submitted to App Store Connect, then the verification job failed with:

```
##[error]Unable to download artifact(s): Artifact not found for name: Build.ipa
```

The artifact name was right; the upload path was not.

## Fix

- Use the **root-agnostic pattern the `ios-kmp-build` action already uses**: `./**/build_output/*`. Preferred over hardcoding `iosApp/` because `custom_build_path` can relocate the output (e.g. `iosApp/appA`), which a hardcoded prefix would break.
- Set **`if-no-files-found: error`** on both steps, so a future path regression fails loudly instead of silently shipping a release with no IPA and no symbols.

## Deliberately not changed

The non-KMP `ios-selfhosted-release.yml`, `ios-selfhosted-on-demand-build.yml` and `ios-selfhosted-nightly-build.yml` use the same `build_output/*` pattern, but they **do not pass `ios_root_path`** — the input defaults to the current directory, so Fastlane runs at the repository root and their patterns are **correct**. Only the genuinely broken workflow is touched here.

## Verification

- YAML parses; both upload steps carry the new path and `if-no-files-found: error`.
- The `./**/build_output/*` glob is empirically proven: the identical pattern in `.github/actions/ios-kmp-build/action.yml` produced `Build.ipa` (40 MB) and `Build.app.dSYM.zip` (49 MB) from `iosApp/build_output/` in akcenta-kmp's on-demand build run.
- `actionlint` was not run locally (not installed); `workflows-lint` covers it here.

## Follow-up for consumers

This needs a new tag (e.g. `2.4.3`) before consuming projects pick it up — akcenta-kmp pins `@2.4.2` and will bump once tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)