### PR TITLE
feat: add kmp_build_mode input to ios-kmp-selfhosted-test

### DIFF
--- a/.github/workflows/ios-kmp-selfhosted-test.yml
+++ b/.github/workflows/ios-kmp-selfhosted-test.yml
@@ -32,6 +32,11 @@ on:
         type: string
         default: dev
         required: false
+      kmp_build_mode:
+        description: "Which XCFramework slices to build, if the project's KMP Makefile supports the KMP_BUILD_MODE variable (forwarded as -PkmpBuildMode). Use 'simulator' to skip the unused device slice on PR test runs. Empty (default) keeps the project's default behavior."
+        type: string
+        required: false
+        default: ''
       java_version:
         description: "Java version to use"
         required: false
@@ -79,6 +84,9 @@ jobs:
         env:
           KMP_BUILD_FLAVOR: ${{ inputs.kmp_swift_package_flavor }}
           KMP_FRAMEWORK_BUILD_TYPE: debug
+          # Empty when the input is unset: GNU make's `ifdef` treats an empty variable as
+          # undefined, so Makefiles without KMP_BUILD_MODE support are unaffected.
+          KMP_BUILD_MODE: ${{ inputs.kmp_build_mode }}
         run: |
           cd ${{ inputs.kmp_swift_package_path }}
           make build


### PR DESCRIPTION
## Motivation

KMP projects generated from the template default to building **all** XCFramework slices (`iosArm64` + `iosSimulatorArm64`) — `shared/app/build.gradle.kts` falls back to `"all"` when `-PkmpBuildMode` is not passed, and this workflow never sets `KMP_BUILD_MODE`, so the KMP `Makefile` never forwards it.

The `Fastlane Test` step that follows only ever runs **simulator** tests, so the `iosArm64` device slice is compiled and linked on every PR run and then never used. On `tetadrogerie-kmp` the `Build KMP Package` step takes ~3 min per PR; roughly half of that is the unused device slice (Kotlin/Native link time scales with the number of slices).

## Change

New optional `kmp_build_mode` string input, exported as `KMP_BUILD_MODE` on the `Build KMP Package` step. Callers whose PR checks only run simulator tests can pass:

```yaml
  check-ios:
    uses: futuredapp/.github/.github/workflows/ios-kmp-selfhosted-test.yml@<next-tag>
    with:
      kmp_swift_package_integration: true
      kmp_build_mode: simulator
```

## Backwards compatibility

- Default is `''` → the env var is empty → GNU make's `ifdef KMP_BUILD_MODE` treats an empty variable as undefined → `-PkmpBuildMode` is not passed → existing behavior (`all`) is unchanged for every current caller.
- Projects whose Makefile has no `KMP_BUILD_MODE` handling simply ignore the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xxj9PVQVi9z8nB6rGHbEg