### PR TITLE
Make App Store Connect API key issuer ID optional

### DIFF
--- a/.github/actions/ios-fastlane-beta/action.yml
+++ b/.github/actions/ios-fastlane-beta/action.yml
@@ -14,8 +14,8 @@ inputs:
     description: 'App Store Connect API Key ID'
     required: true
   app_store_connect_api_key_issuer_id:
-    description: 'App Store Connect API Key Issuer ID'
-    required: true
+    description: 'App Store Connect API Key Issuer ID. Optional, because individual (user-based) API keys have no issuer ID.'
+    required: false
   build_number:
     description: 'Custom build number. Skips auto-increment from TestFlight.'
     required: false

--- a/.github/actions/ios-fastlane-release/action.yml
+++ b/.github/actions/ios-fastlane-release/action.yml
@@ -17,8 +17,8 @@ inputs:
     description: 'App Store Connect API Key ID'
     required: true
   app_store_connect_api_key_issuer_id:
-    description: 'App Store Connect API Key Issuer ID'
-    required: true
+    description: 'App Store Connect API Key Issuer ID. Optional, because individual (user-based) API keys have no issuer ID.'
+    required: false
   custom_values:
     description: 'Custom values'
     required: false

--- a/.github/actions/ios-kmp-build/action.yml
+++ b/.github/actions/ios-kmp-build/action.yml
@@ -12,10 +12,10 @@ inputs:
   app_store_connect_api_key_key_id:
     required: true
     description: "Private App Store Connect API key for submitting build to App Store."
-  app_store_connect_api_key_issuer_id:
-    required: true
-    description: "Private App Store Connect API issuer key for submitting build to App Store."
   # Optional
+  app_store_connect_api_key_issuer_id:
+    required: false
+    description: "Private App Store Connect API issuer key for submitting build to App Store. Optional, because individual (user-based) API keys have no issuer ID."
   secret_xcconfig_path:
     description: "Path to the .xcconfig file. Selected secret properties will be appended to the end of this file."
     required: false

--- a/.github/workflows/ios-kmp-selfhosted-build.yml
+++ b/.github/workflows/ios-kmp-selfhosted-build.yml
@@ -76,9 +76,10 @@ on:
         description: >
           Private App Store Connect API key for submitting build to App Store.
       APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
+        required: false
         description: >
           Private App Store Connect API issuer key for submitting build to App Store.
+          Optional, because individual (user-based) API keys have no issuer ID.
       GRADLE_CACHE_ENCRYPTION_KEY:
         required: false
         description: "Configuration cache encryption key"

--- a/.github/workflows/ios-kmp-selfhosted-release.yml
+++ b/.github/workflows/ios-kmp-selfhosted-release.yml
@@ -71,9 +71,10 @@ on:
         description: >
           Private App Store Connect API key for submitting build to App Store.
       APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
+        required: false
         description: >
           Private App Store Connect API issuer key for submitting build to App Store.
+          Optional, because individual (user-based) API keys have no issuer ID.
       SECRET_PROPERTIES:
         required: false
         description: >

--- a/.github/workflows/ios-selfhosted-build.yml
+++ b/.github/workflows/ios-selfhosted-build.yml
@@ -48,8 +48,8 @@ on:
         required: true
         description: 'Private App Store Connect API key for submitting build to App Store.'
       APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
-        description: 'Private App Store Connect API issuer key for submitting build to App Store.'
+        required: false
+        description: 'Private App Store Connect API issuer key for submitting build to App Store. Optional, because individual (user-based) API keys have no issuer ID.'
       SECRET_PROPERTIES:
         required: false
         description: 'Secrets in the format KEY = VALUE (one per line).'

--- a/.github/workflows/ios-selfhosted-nightly-build.yml
+++ b/.github/workflows/ios-selfhosted-nightly-build.yml
@@ -60,8 +60,8 @@ on:
         required: true
         description: 'Private App Store Connect API key for submitting build to App Store.'
       APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
-        description: 'Private App Store Connect API issuer key for submitting build to App Store.'
+        required: false
+        description: 'Private App Store Connect API issuer key for submitting build to App Store. Optional, because individual (user-based) API keys have no issuer ID.'
       SECRET_PROPERTIES:
         required: false
         description: 'Secrets in the format KEY = VALUE (one per line).'

--- a/.github/workflows/ios-selfhosted-on-demand-build.yml
+++ b/.github/workflows/ios-selfhosted-on-demand-build.yml
@@ -66,8 +66,8 @@ on:
         required: true
         description: 'Private App Store Connect API key for submitting build to App Store.'
       APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
-        description: 'Private App Store Connect API issuer key for submitting build to App Store.'
+        required: false
+        description: 'Private App Store Connect API issuer key for submitting build to App Store. Optional, because individual (user-based) API keys have no issuer ID.'
       SECRET_PROPERTIES:
         required: false
         description: 'Secrets in the format KEY = VALUE (one per line).'

--- a/.github/workflows/ios-selfhosted-release.yml
+++ b/.github/workflows/ios-selfhosted-release.yml
@@ -43,8 +43,8 @@ on:
         required: true
         description: 'Private App Store Connect API key for submitting build to App Store.'
       APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
-        description: 'Private App Store Connect API issuer key for submitting build to App Store.'
+        required: false
+        description: 'Private App Store Connect API issuer key for submitting build to App Store. Optional, because individual (user-based) API keys have no issuer ID.'
       SECRET_PROPERTIES:
         required: false
         description: 'Secrets in the format KEY = VALUE (one per line).'

--- a/.github/workflows/kmp-combined-nightly-build.yml
+++ b/.github/workflows/kmp-combined-nightly-build.yml
@@ -134,8 +134,8 @@ on:
         required: true
         description: "Private App Store Connect API key for submitting build to App Store."
       IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID:
-        required: true
-        description: "Private App Store Connect API issuer key for submitting build to App Store."
+        required: false
+        description: "Private App Store Connect API issuer key for submitting build to App Store. Optional, because individual (user-based) API keys have no issuer ID."
       JIRA_CONTEXT:
         required: false
         description: "JIRA context for transitioning tickets."


### PR DESCRIPTION
## Why

Individual (user-based) App Store Connect API keys have no issuer ID. As long as `APP_STORE_CONNECT_API_KEY_ISSUER_ID` was declared `required: true`, projects using such a key could not call these workflows.

## What

Flipped `required: true` → `required: false` for the issuer ID (and noted the reason in its description) in:

**Reusable workflows** (secret declarations — these are actually enforced by GitHub):
- `ios-selfhosted-release.yml`
- `ios-selfhosted-nightly-build.yml`
- `ios-selfhosted-on-demand-build.yml`
- `ios-selfhosted-build.yml` (deprecated)
- `ios-kmp-selfhosted-release.yml`
- `ios-kmp-selfhosted-build.yml`
- `kmp-combined-nightly-build.yml` (`IOS_APP_STORE_CONNECT_API_KEY_ISSUER_ID`)

**Composite actions** (inputs):
- `ios-fastlane-beta`
- `ios-fastlane-release`
- `ios-kmp-build` (also moved the input under the `# Optional` marker)

No behavioural change for projects that do pass an issuer ID — the value is still forwarded to Fastlane unchanged. `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)