### PR TITLE
fix: unset empty App Store Connect API key issuer ID

### DIFF
--- a/.github/actions/ios-fastlane-beta/beta.sh
+++ b/.github/actions/ios-fastlane-beta/beta.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Individual keys have no issuer ID, but an omitted secret arrives as "", which
+# is truthy in Ruby — fastlane would sign iss: "" instead of sub: "user".
+if [ -z "${APP_STORE_CONNECT_API_KEY_ISSUER_ID//[[:space:]]/}" ]; then
+  unset APP_STORE_CONNECT_API_KEY_ISSUER_ID
+fi
+
 # Change to iOS root for bundle install
 if [ -n "$IOS_ROOT_PATH" ]; then
   echo "Installing gems from: $IOS_ROOT_PATH"

--- a/.github/actions/ios-fastlane-beta/test/test_beta.bats
+++ b/.github/actions/ios-fastlane-beta/test/test_beta.bats
@@ -27,3 +27,21 @@ SCRIPT="$BATS_TEST_DIRNAME/../beta.sh"
   [ "$status" -eq 0 ]
   grep -q "^exec fastlane beta build_number:42 version_number:1.2.0$" "$BUNDLE_LOG"
 }
+
+@test "empty issuer ID — unset so fastlane treats the key as individual" {
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID="" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q "^APP_STORE_CONNECT_API_KEY_ISSUER_ID=" "$ENV_LOG"
+}
+
+@test "whitespace-only issuer ID — unset" {
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID="  " run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q "^APP_STORE_CONNECT_API_KEY_ISSUER_ID=" "$ENV_LOG"
+}
+
+@test "issuer ID set — passed through to fastlane" {
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID="abc-123" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -q "^APP_STORE_CONNECT_API_KEY_ISSUER_ID=abc-123$" "$ENV_LOG"
+}

--- a/.github/actions/ios-fastlane-beta/test/test_helper.bash
+++ b/.github/actions/ios-fastlane-beta/test/test_helper.bash
@@ -9,13 +9,15 @@ exit 0
 MOCK
   chmod +x "$MOCK_DIR/gem"
 
-  # Mock bundle command — capture the full invocation
+  # Mock bundle command — capture the full invocation and the env fastlane sees
   BUNDLE_LOG="$(mktemp)"
-  export BUNDLE_LOG
+  ENV_LOG="$(mktemp)"
+  export BUNDLE_LOG ENV_LOG
   cat > "$MOCK_DIR/bundle" <<MOCK
 #!/bin/bash
 if [ "\$1" = "exec" ]; then
   echo "\$@" >> "$BUNDLE_LOG"
+  env > "$ENV_LOG"
 fi
 exit 0
 MOCK
@@ -23,5 +25,5 @@ MOCK
 }
 
 teardown() {
-  rm -rf "$MOCK_DIR" "$BUNDLE_LOG"
+  rm -rf "$MOCK_DIR" "$BUNDLE_LOG" "$ENV_LOG"
 }

--- a/.github/actions/ios-fastlane-release/release.sh
+++ b/.github/actions/ios-fastlane-release/release.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Individual keys have no issuer ID, but an omitted secret arrives as "", which
+# is truthy in Ruby — fastlane would sign iss: "" instead of sub: "user".
+if [ -z "${APP_STORE_CONNECT_API_KEY_ISSUER_ID//[[:space:]]/}" ]; then
+  unset APP_STORE_CONNECT_API_KEY_ISSUER_ID
+fi
+
 # Change to iOS root for bundle install
 if [ -n "$IOS_ROOT_PATH" ]; then
   echo "Installing gems from: $IOS_ROOT_PATH"

--- a/.github/actions/ios-fastlane-release/test/test_release.bats
+++ b/.github/actions/ios-fastlane-release/test/test_release.bats
@@ -15,13 +15,15 @@ exit 0
 MOCK
   chmod +x "$MOCK_DIR/gem"
 
-  # Mock bundle command — capture the full invocation
+  # Mock bundle command — capture the full invocation and the env fastlane sees
   BUNDLE_LOG="$(mktemp)"
-  export BUNDLE_LOG
+  ENV_LOG="$(mktemp)"
+  export BUNDLE_LOG ENV_LOG
   cat > "$MOCK_DIR/bundle" <<MOCK
 #!/bin/bash
 if [ "\$1" = "exec" ]; then
   echo "\$@" >> "$BUNDLE_LOG"
+  env > "$ENV_LOG"
 fi
 exit 0
 MOCK
@@ -29,7 +31,7 @@ MOCK
 }
 
 teardown() {
-  rm -rf "$MOCK_DIR" "$BUNDLE_LOG"
+  rm -rf "$MOCK_DIR" "$BUNDLE_LOG" "$ENV_LOG"
 }
 
 @test "no overrides — runs fastlane release without args" {
@@ -54,4 +56,22 @@ teardown() {
   BUILD_NUMBER="42" VERSION_NUMBER="1.2.0" run bash "$SCRIPT"
   [ "$status" -eq 0 ]
   grep -q "^exec fastlane release build_number:42 version_number:1.2.0$" "$BUNDLE_LOG"
+}
+
+@test "empty issuer ID — unset so fastlane treats the key as individual" {
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID="" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q "^APP_STORE_CONNECT_API_KEY_ISSUER_ID=" "$ENV_LOG"
+}
+
+@test "whitespace-only issuer ID — unset" {
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID="  " run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  ! grep -q "^APP_STORE_CONNECT_API_KEY_ISSUER_ID=" "$ENV_LOG"
+}
+
+@test "issuer ID set — passed through to fastlane" {
+  APP_STORE_CONNECT_API_KEY_ISSUER_ID="abc-123" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  grep -q "^APP_STORE_CONNECT_API_KEY_ISSUER_ID=abc-123$" "$ENV_LOG"
 }


### PR DESCRIPTION
## Problem

Releases using an **individual** App Store Connect API key fail on the first ASC call with `Authentication credentials are missing or invalid`.

2.4.4 (#115) made the issuer ID optional only in the input/secret *declarations* — both actions still set the env var unconditionally, so an omitted secret reaches fastlane as `""` rather than absent. `""` is truthy in Ruby, so spaceship takes the team-key branch and signs `iss: ""` instead of the individual-key `sub: "user"`. Apple rejects that token.

Reproduced on fastlane 2.237.0:

```
issuer_id=""  -> iss=""  sub=nil
issuer_id=nil -> iss=nil sub="user"
```

## Fix

Unset the variable in `beta.sh` and `release.sh` when it is empty or whitespace-only (fastlane's own `.strip` would collapse a padded value back to `""`). `unset` rather than a conditional export, so a stale value in the self-hosted runner environment can't leak in.

These two scripts are the only place the variable reaches fastlane, so this covers all seven affected workflows — the release ones via `ios-fastlane-release`, the build/nightly and KMP ones via `ios-fastlane-beta` (KMP through `ios-kmp-build`).

## Tests

Empty / whitespace-only / valid per action, asserting on the environment the mocked `bundle exec` actually sees. 24 pass; the two negative cases were confirmed to fail without the fix.

## Note

Necessary regardless, but only *sufficient* if the key really is an Individual Key (that page in ASC shows no Issuer ID). A Team Key produces the identical 401 and needs the issuer secret supplied instead.

Needs a 2.4.5 tag + ref bump as the usual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)